### PR TITLE
Adjust the tests to harbuzz 2.6.6

### DIFF
--- a/t/10_basic.t
+++ b/t/10_basic.t
@@ -16,7 +16,6 @@ $hb->set_size(36);
 $hb->set_text("Hell€!");
 my $info = $hb->shaper;
 # use DDumper; DDumper($info);
-# It's a pity this font does not have glyph names.
 my $result = [
   {
     ax => '25.992',
@@ -24,7 +23,7 @@ my $result = [
     dx => 0,
     dy => 0,
     g => 41,
-    name => '',
+    name => 'H',
   },
   {
     ax => '15.192',
@@ -32,7 +31,7 @@ my $result = [
     dx => 0,
     dy => 0,
     g => 70,
-    name => '',
+    name => 'e',
   },
   {
     ax => '10.008',
@@ -40,7 +39,7 @@ my $result = [
     dx => 0,
     dy => 0,
     g => 77,
-    name => '',
+    name => 'l',
   },
   {
     ax => '10.008',
@@ -48,7 +47,7 @@ my $result = [
     dx => 0,
     dy => 0,
     g => 77,
-    name => '',
+    name => 'l',
   },
   {
     ax => 18,
@@ -56,7 +55,7 @@ my $result = [
     dx => 0,
     dy => 0,
     g => 347,
-    name => '',
+    name => 'Euro',
   },
   {
     ax => '11.988',
@@ -64,7 +63,7 @@ my $result = [
     dx => 0,
     dy => 0,
     g => 2,
-    name => '',
+    name => 'exclam',
   },
 ];
 
@@ -84,7 +83,9 @@ sub compare {
 	    diag( "CId $i->{g} must be $j->{g}" );
 	    return;
 	}
-	unless ( $i->{name} eq $j->{name} ) {
+	# It's a pity this font does not have glyph names.
+	# But harbuzz 2.6.6 started to return them.
+	unless ( $i->{name} eq $j->{name} or '' eq $j->{name}) {
 	    diag( "Name $i->{name} must be $j->{name}" );
 	    return;
 	}

--- a/t/30_kern.t
+++ b/t/30_kern.t
@@ -17,10 +17,10 @@ $hb->set_text("LVAT");
 my $info = $hb->shaper;
 #use DDumper; DDumper($info);
 my $result = [
-  { ax => '17.856', ay => 0, dx => 0, dy => 0, g => 45, name => '' },
-  { ax => '21.672', ay => 0, dx => 0, dy => 0, g => 55, name => '' },
-  { ax => '24.048', ay => 0, dx => 0, dy => 0, g => 34, name => '' },
-  { ax => '21.996', ay => 0, dx => 0, dy => 0, g => 53, name => '' },
+  { ax => '17.856', ay => 0, dx => 0, dy => 0, g => 45, name => 'L' },
+  { ax => '21.672', ay => 0, dx => 0, dy => 0, g => 55, name => 'V' },
+  { ax => '24.048', ay => 0, dx => 0, dy => 0, g => 34, name => 'A' },
+  { ax => '21.996', ay => 0, dx => 0, dy => 0, g => 53, name => 'T' },
 ];
 
 ok(compare( $info, $result ), "content default kern" );
@@ -33,10 +33,10 @@ ok(compare( $info, $result ), "content +kern feature" );
 $info = $hb->shaper( [ '-kern' ] );
 
 $result = [
-  { ax => '21.996', ay => 0, dx => 0, dy => 0, g => 45, name => '' },
-  { ax => '25.992', ay => 0, dx => 0, dy => 0, g => 55, name => '' },
-  { ax => '25.992', ay => 0, dx => 0, dy => 0, g => 34, name => '' },
-  { ax => '21.996', ay => 0, dx => 0, dy => 0, g => 53, name => '' },
+  { ax => '21.996', ay => 0, dx => 0, dy => 0, g => 45, name => 'L' },
+  { ax => '25.992', ay => 0, dx => 0, dy => 0, g => 55, name => 'V' },
+  { ax => '25.992', ay => 0, dx => 0, dy => 0, g => 34, name => 'A' },
+  { ax => '21.996', ay => 0, dx => 0, dy => 0, g => 53, name => 'T' },
 ];
 
 ok(compare( $info, $result ), "content -kern feature" );
@@ -55,7 +55,7 @@ sub compare {
 	    diag( "CId $i->{g} must be $j->{g}" );
 	    return;
 	}
-	unless ( $i->{name} eq $j->{name} ) {
+	unless ( $i->{name} eq $j->{name} or $i->{name} eq '' ) {
 	    diag( "Name $i->{name} must be $j->{name}" );
 	    return;
 	}


### PR DESCRIPTION
harfbuzz 2.6.6 started to return glyph names. That caused the tests to
fail. This patch fixes it.

https://github.com/sciurius/perl-HarfBuzz-Shaper/issues/5