### PR TITLE
Make pkg-config configurable in Makefile.PL

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -66,12 +66,13 @@ my $hb_src = "hb_src.tar.gz";
 my $got_hb = $ENV{INCHS} ? -1 : 0;
 
 # First, try pkg-config.
-my $res = `pkg-config --version`;
+my $pkg_config = $ENV{'PKG_CONFIG'} // "pkg-config";
+my $res = `$pkg_config --version`;
 if ( !$got_hb && $res =~ /\d+\.\d+/ ) {
-    $res = `pkg-config --libs harfbuzz`;
+    $res = `$pkg_config --libs harfbuzz`;
     if ( $res =~ /(?:(-L.+)\s+)?(-l.+)/ ) {
 	$args{LIBS} = [ $res ];
-	$res = `pkg-config --cflags harfbuzz`;
+	$res = `$pkg_config --cflags harfbuzz`;
 	if ( $res =~ /-I.+/ ) {
 	    $args{INC} = $res;
 	}


### PR DESCRIPTION
This change makes pkg-config configurable via environment variable PKG_CONFIG (falling back to pkg-config).
This makes cross building the package possible.
The patch was provided by Helmut Grohne <helmut@subdivi.de> for the Debian distribution, see https://bugs.debian.org/1117015.